### PR TITLE
Consider using bias=False when using batchnorm

### DIFF
--- a/cvivit.py
+++ b/cvivit.py
@@ -142,7 +142,7 @@ class VIVIT(nn.Module):
         super().__init__()
         self.encoder = Encoder(patch_size=patch_size, hidden_channels=c_hidden, size=latent_size, compressed_frames=compressed_frames,
                                num_layers=num_layers_enc, num_heads=num_heads)
-        self.cod_mapper = nn.Linear(c_hidden, c_codebook)
+        self.cod_mapper = nn.Linear(c_hidden, c_codebook, bias=False)
         self.batchnorm = nn.BatchNorm2d(c_codebook)
 
         self.cod_unmapper = nn.Linear(c_codebook, c_hidden)

--- a/vivq.py
+++ b/vivq.py
@@ -210,7 +210,7 @@ class VIVQ(nn.Module):
         super().__init__()
         self.encoder = Encoder(base_channels, c_hidden=c_hidden)
         self.cod_mapper = nn.Sequential(
-            nn.Conv3d(c_hidden, c_codebook, kernel_size=1),
+            nn.Conv3d(c_hidden, c_codebook, kernel_size=1, bias=False),
             nn.BatchNorm3d(c_codebook),
         )
         self.cod_unmapper = nn.Conv3d(c_codebook, c_hidden, kernel_size=1)


### PR DESCRIPTION
If I'm not mistaken the bias is not needed in these conv. and linear layers since there are followed by batch norm.

See original batch norm [paper](https://arxiv.org/pdf/1502.03167.pdf#page=5) or https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html#disable-bias-for-convolutions-directly-followed-by-a-batch-norm